### PR TITLE
fix: cpf validation rule

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ docs
 vendor
 coverage
 .idea
+.phpunit.result.cache

--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "ext-mbstring": "*"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.0"
+        "phpunit/phpunit": "^10.4"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="vendor/autoload.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,16 +9,4 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage" charset="UTF-8" yui="true" highlight="true"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
 </phpunit>

--- a/src/Rules/Cpf.php
+++ b/src/Rules/Cpf.php
@@ -33,14 +33,14 @@ class Cpf implements Rule
     public function passes($attribute, $value): bool
     {
         if (empty($value)) {
-            return true;
+            return false;
         }
 
         if ($this->allowMask) {
             $value = preg_replace('/\D/', '', $value);
         }
 
-        if (!($value && mb_strlen($value) === 11)) {
+        if (mb_strlen($value) !== 11) {
             return false;
         }
 

--- a/tests/CpfTest.php
+++ b/tests/CpfTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace Melhorenvio\ValidationRules\Tests;
+
+use Melhorenvio\ValidationRules\Rules\Cpf;
+use PHPUnit\Framework\TestCase;
+
+class CpfTest extends TestCase
+{
+    /**
+     * @test
+     * @dataProvider provideInvalidCpfs
+     */
+    public function test_with_invalid_cpfs(string $cpf)
+    {
+        $rule = new Cpf();
+
+        $this->assertFalse($rule->passes('cpf', $cpf));
+    }
+
+    /**
+     * @test
+     * @dataProvider provideValidCpfs
+     */
+    public function test_with_valid_cpfs(string $cpf)
+    {
+        $rule = new Cpf();
+
+        $this->assertTrue($rule->passes('cpf', $cpf));
+    }
+
+    public function test_with_empty_cpf()
+    {
+        $rule = new Cpf();
+
+        $this->assertFalse($rule->passes('cpf', ''));
+        $this->assertFalse($rule->passes('cpf', null));
+    }
+
+    public static function provideInvalidCpfs(): array
+    {
+        return [
+            ['00000000000'],
+            ['11111111111'],
+            ['22222222222'],
+            ['33333333333'],
+            ['44444444444'],
+            ['55555555555'],
+            ['66666666666'],
+            ['77777777777'],
+            ['88888888888'],
+            ['99999999999'],
+            ['000.000.000-00'],
+            ['111.111.111-11'],
+            ['222.222.222-22'],
+            ['333.333.333-33'],
+            ['444.444.444-44'],
+            ['555.555.555-55'],
+            ['666.666.666-66'],
+            ['777.777.777-77'],
+            ['888.888.888-88'],
+            ['999.999.999-99'],
+        ];
+    }
+
+    public static function provideValidCpfs(): array
+    {
+        return [
+            ['322.282.090-23'],
+            ['024.278.590-52'],
+            ['014.533.750-23'],
+            ['335.203.900-35'],
+            ['108.810.610-26'],
+            ['97005733037'],
+            ['86939244000'],
+            ['62747195040'],
+            ['75726024010'],
+            ['45061931050'],
+        ];
+    }
+}

--- a/tests/CpfTest.php
+++ b/tests/CpfTest.php
@@ -37,6 +37,14 @@ class CpfTest extends TestCase
         $this->assertFalse($rule->passes('cpf', null));
     }
 
+    public function test_with_zeroed_cpf()
+    {
+        $rule = new Cpf();
+
+        $this->assertFalse($rule->passes('cpf', '0'));
+        $this->assertFalse($rule->passes('cpf', 0));
+    }
+
     public static function provideInvalidCpfs(): array
     {
         return [
@@ -59,7 +67,7 @@ class CpfTest extends TestCase
             ['666.666.666-66'],
             ['777.777.777-77'],
             ['888.888.888-88'],
-            ['999.999.999-99'],
+            ['999.999.999-99']
         ];
     }
 


### PR DESCRIPTION
**Confirmar antes de mergear!**

Considero que seja um fix (patch) tendo em vista que a versão anterior estava aceitando como válidos CPFs _0, vazio e null_.
